### PR TITLE
Erased d_extension import of missing file dmonomial

### DIFF
--- a/dalgebra/dextension/__init__.py
+++ b/dalgebra/dextension/__init__.py
@@ -21,4 +21,3 @@ AUTHORS:
 # ****************************************************************************
 
 from .delliptic import *
-from .dmonomial import *


### PR DESCRIPTION
I've deleted .dmonomial import. I had not used the package yet, so maybe instead there is a file missing?